### PR TITLE
PLATFORM-736: improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,34 @@ $ ./env/bin/webhooks-server
 ```
 $ curl -v "http://127.0.0.1:8088/github-webhook/" -d @webhooks/examples/push.json -H "X-GitHub-Event: push" -H "Content-Type: application/json"
 ```
+
+## Responses
+
+`HTTP 201`: Jenkins jobs were triggered (the list can be empty if there was no match)
+
+```json
+{
+  "jobs_started": [
+    {
+      "params": {
+        "repo": "Wikia/app",
+        "commit": "4d2ab4e76d0d405d17d1a0f2b8a6071394e3ab40",
+        "email": "kyle.daigle@github.com",
+        "branch": "wikia-logger-backtrace-for-errors",
+        "author": "Kyle Daigle"
+      },
+      "name": "sparrow_runner"
+    }
+  ]
+}
+```
+
+`HTTP 404`: Jenkins job specified in `config.yaml` was not found on Jenkins
+
+```json
+{
+  "error": "Jenkins job was not found: foo_bar"
+}
+```
+
+`HTTP 501`: internal error

--- a/webhooks/app.py
+++ b/webhooks/app.py
@@ -6,18 +6,21 @@ import json
 import logging
 import sys
 
+# set up Flask app
 from flask import Flask, request
-
 from .github_event_handler import GithubEventHandler
 
-app = Flask(__name__)
+# set up the logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('jenkins-webhooks')
 
+app = Flask(__name__)
 github_event_handler = GithubEventHandler()
 
-# log to stderr
-logger = logging.getLogger('jenkins-webhooks')
-logger.setLevel(logging.DEBUG)
-logger.addHandler(logging.StreamHandler())
+
+@app.route("/", methods=['GET'])
+def home_page():
+    return "Hi!"
 
 
 @app.route("/github-webhook/", methods=['POST'])

--- a/webhooks/config.py
+++ b/webhooks/config.py
@@ -69,10 +69,7 @@ class Config(object):
         """
         Creates an instance of Config class from given YAML file
         """
-        logger = logging.getLogger('jenkins-webhooks-config')
-        logger.setLevel(logging.DEBUG)
-        logger.addHandler(logging.StreamHandler())
-
+        logger = logging.getLogger(__name__)
         logger.info("Reading config from %s", file_name)
 
         with open(file_name, 'r') as stream:

--- a/webhooks/github_event_handler.py
+++ b/webhooks/github_event_handler.py
@@ -83,7 +83,7 @@ class GithubEventHandler(object):
                 for job_name in match['jobs']:
                     self._logger.info("Running %s with params: %s", job_name, job_params)
                     self.__jenkins.build_job(job_name, job_params)
-        else:
-            self._logger.info("No match found")
+            else:
+                raise Exception("No match found")
 
         return 'OK'

--- a/webhooks/github_event_handler.py
+++ b/webhooks/github_event_handler.py
@@ -9,6 +9,10 @@ from pkg_resources import resource_filename
 from .config import Config
 
 
+class GithubEventException(Exception):
+    pass
+
+
 class GithubEventHandler(object):
 
     def __init__(self, config=None, jenkins=None):
@@ -76,6 +80,8 @@ class GithubEventHandler(object):
             if k in job_param_keys
         ])
 
+        jobs_started = []
+
         for match in matches:
             self._logger.info("Event matches: %s", json.dumps(match))
 
@@ -83,7 +89,9 @@ class GithubEventHandler(object):
                 for job_name in match['jobs']:
                     self._logger.info("Running %s with params: %s", job_name, job_params)
                     self.__jenkins.build_job(job_name, job_params)
-            else:
-                raise Exception("No match found")
 
-        return 'OK'
+                    jobs_started.append({'name': job_name, 'params': job_params})
+            else:
+                raise GithubEventException("No match found")
+
+        return jobs_started


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-736

Return `HTTP 201` with the following on a successful Jenkins trigger:

```json
{
  "jobs_started": [
    {
      "params": {
        "repo": "Wikia/app",
        "commit": "4d2ab4e76d0d405d17d1a0f2b8a6071394e3ab40",
        "email": "kyle.daigle@github.com",
        "branch": "wikia-logger-backtrace-for-errors",
        "author": "Kyle Daigle"
      },
      "name": "sparrow_runner"
    }
  ]
}
```

Return `HTTP 404` when the Jenkins job was not found:

```json
{
  "error": "Jenkins job was not found: foo_bar"
}
```

Return `HTTP 501` on the service internal error

+ some code cleanup

@wladekb / @jcellary / @michalroszka / @hakubo 