### PR TITLE
GithubEventHandler: do not wait before sending a job spawn request to Jenkins

### DIFF
--- a/webhooks/github_event_handler.py
+++ b/webhooks/github_event_handler.py
@@ -102,10 +102,12 @@ class GithubEventHandler(object):
                 try:
                     for job_name in match['jobs']:
                         self._logger.info("Running %s with params: %s", job_name, job_params)
-                        res = self.__jenkins.build_job(job_name, job_params)
+                        self.__jenkins[job_name].invoke(
+                            build_params=job_params,
+                            invoke_pre_check_delay=0
+                        )
 
-                        self._logger.info("Run of %s job scheduled, response from Jenkins: %s",
-                                          job_name, json.dumps(res))
+                        self._logger.info("Run of %s job scheduled", job_name)
 
                         jobs_started.append({'name': job_name, 'params': job_params})
                 except UnknownJob as e:


### PR DESCRIPTION
[OPS-8043](https://wikia-inc.atlassian.net/browse/OPS-8043)

@rmarchei 