### PR TITLE
PersistentRequester: use connections pool

### DIFF
--- a/webhooks/github_event_handler.py
+++ b/webhooks/github_event_handler.py
@@ -9,6 +9,7 @@ from jenkinsapi.custom_exceptions import JenkinsAPIException, NotFound
 
 from pkg_resources import resource_filename
 from .config import Config
+from .requestor import PersistentRequester
 
 
 class GithubEventException(Exception):
@@ -29,11 +30,17 @@ class GithubEventHandler(object):
             self.__config = Config.from_yaml(config_file)
 
         if self.__jenkins is None:
+            requester = PersistentRequester(
+                self.__config.get_jenkins_user(),
+                self.__config.get_jenkins_pass(),
+                baseurl=self.__config.get_jenkins_url(),
+            )
+
             self.__jenkins = Jenkins(
                 baseurl=self.__config.get_jenkins_url(),
                 username=self.__config.get_jenkins_user(),
                 password=self.__config.get_jenkins_pass(),
-                lazy=True
+                requester=requester
             )
 
     @staticmethod

--- a/webhooks/requestor.py
+++ b/webhooks/requestor.py
@@ -1,0 +1,40 @@
+"""
+Jenkins API does not use persistent HTTP connections feature of request Python module
+
+THis class extends jenkinsapi.utils.requester.Requester class and uses requests.Session()
+"""
+
+import requests
+
+from jenkinsapi.utils.requester import Requester
+
+
+class PersistentRequester(Requester):
+    """
+    Override get_url and post_url methods that make HTTP requests and use HTTP connections pooling
+    """
+    _request = None
+
+    @property
+    def request(self):
+        if self._request is None:
+            self._request = requests.Session()
+
+        return self._request
+
+    def get_url(self, url, params=None, headers=None, allow_redirects=True):
+        requestKwargs = self.get_request_dict(
+            params=params,
+            headers=headers,
+            allow_redirects=allow_redirects)
+        return self.request.get(self._update_url_scheme(url), **requestKwargs)
+
+    def post_url(self, url, params=None, data=None, files=None,
+                 headers=None, allow_redirects=True):
+        requestKwargs = self.get_request_dict(
+            params=params,
+            data=data,
+            files=files,
+            headers=headers,
+            allow_redirects=allow_redirects)
+        return self.request.post(self._update_url_scheme(url), **requestKwargs)


### PR DESCRIPTION
Spawning four jobs now takes 3-4 seconds, instead of 10 seconds

@rmarchei 