### PR TITLE
Update jenkins API lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     packages=['webhooks'],
     install_requires=[
         'Flask==0.10.1',
-        'jenkinsapi==0.2.29',
+        'jenkinsapi==0.3.6',
         'pytest==2.6.0',
         'pyyaml==3.11',
         'mock==1.0.1',


### PR DESCRIPTION
Updated jenkins API lib, cause the old one does not handle parameters on pipelines when triggering jobs: 
```2018-03-20 13:41:11 [INFO] Event received: {"target_branch": "", "author": "Ludwik", "repo": "Wikia/app", "branch": "dummy-test", "owner": "Wikia", "commit": "45a4c1824641fc6b0f0193a7383bf12fdf06b499", "email": "ludwik.kazmierczak@gmail.com"}
2018-03-20 13:41:11 [INFO] Event matches: {"repo": "Wikia/app", "jobs": ["unitTests_php_branches_clone"], "events": ["push"], "branches_not": ["dev"]}
2018-03-20 13:41:11 [INFO] Running unitTests_php_branches_clone with params: {'repo': 'Wikia/app', 'commit': '45a4c1824641fc6b0f0193a7383bf12fdf06b499', 'email': 'ludwik.kazmierczak@gmail.com', 'branch': 'dummy-test', 'author': 'Ludwik'}
2018-03-20 13:41:16 [ERROR] process_github_event() raised an exception
Traceback (most recent call last):
  File "/Users/ludwikkazmierczak/Projects/jenkins-webhooks/webhooks/app.py", line 49, in index
    jobs_started = github_event_handler.process_github_event(event_type, payload)
  File "/Users/ludwikkazmierczak/Projects/jenkins-webhooks/webhooks/github_event_handler.py", line 120, in process_github_event
    self.__jenkins.build_job(job_name, job_params if job.has_params() else None)
  File "/Users/ludwikkazmierczak/.pyenv/versions/2.7.14/envs/webhooks/lib/python2.7/site-packages/jenkinsapi/jenkins.py", line 165, in build_job
    self[jobname].invoke(build_params=params or {})
  File "/Users/ludwikkazmierczak/.pyenv/versions/2.7.14/envs/webhooks/lib/python2.7/site-packages/jenkinsapi/job.py", line 227, in invoke
    raise ValueError("Not a Queue URL: %s" % redirect_url)
ValueError: Not a Queue URL: http://jenkins.wikia-prod:8080/job/unitTests_php_branches_clone/
2018-03-20 13:41:16 [ERROR] request data:
event-type:
push
payload:```